### PR TITLE
Fixed compilation issues on kernel 5.15

### DIFF
--- a/core/rtw_br_ext.c
+++ b/core/rtw_br_ext.c
@@ -17,7 +17,10 @@
 #ifdef __KERNEL__
 	#include <linux/if_arp.h>
 	#include <net/ip.h>
+	#include <linux/version.h>
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0)
 	#include <net/ipx.h>
+#endif
 	#include <linux/atalk.h>
 	#include <linux/udp.h>
 	#include <linux/if_pppox.h>
@@ -169,6 +172,7 @@ static __inline__ void __nat25_generate_ipv4_network_addr(unsigned char *network
 }
 
 
+ #ifdef _NET_INET_IPX_H_
 static __inline__ void __nat25_generate_ipx_network_addr_with_node(unsigned char *networkAddr,
 		unsigned int *ipxNetAddr, unsigned char *ipxNodeAddr)
 {
@@ -189,6 +193,7 @@ static __inline__ void __nat25_generate_ipx_network_addr_with_socket(unsigned ch
 	memcpy(networkAddr + 1, (unsigned char *)ipxNetAddr, 4);
 	memcpy(networkAddr + 5, (unsigned char *)ipxSocketAddr, 2);
 }
+#endif
 
 
 static __inline__ void __nat25_generate_apple_network_addr(unsigned char *networkAddr,
@@ -330,6 +335,7 @@ static __inline__ int __nat25_network_hash(unsigned char *networkAddr)
 		x = networkAddr[7] ^ networkAddr[8] ^ networkAddr[9] ^ networkAddr[10];
 
 		return x & (NAT25_HASH_SIZE - 1);
+#ifdef _NET_INET_IPX_H_
 	} else if (networkAddr[0] == NAT25_IPX) {
 		unsigned long x;
 
@@ -337,6 +343,7 @@ static __inline__ int __nat25_network_hash(unsigned char *networkAddr)
 		    networkAddr[6] ^ networkAddr[7] ^ networkAddr[8] ^ networkAddr[9] ^ networkAddr[10];
 
 		return x & (NAT25_HASH_SIZE - 1);
+#endif
 	} else if (networkAddr[0] == NAT25_APPLE) {
 		unsigned long x;
 
@@ -889,6 +896,7 @@ int nat25_db_handle(_adapter *priv, struct sk_buff *skb, int method)
 		}
 	}
 
+#ifdef _NET_INET_IPX_H_
 	/*---------------------------------------------------*/
 	/*         Handle IPX and Apple Talk frame          */
 	/*---------------------------------------------------*/
@@ -1109,7 +1117,7 @@ int nat25_db_handle(_adapter *priv, struct sk_buff *skb, int method)
 
 		return -1;
 	}
-
+#endif
 	/*---------------------------------------------------*/
 	/*                Handle PPPoE frame                */
 	/*---------------------------------------------------*/


### PR DESCRIPTION
Removed IPX support for the driver, since it is not supported by the Linux kernel since v5.15-rc1 (see [torvalds/linux@6c9b408](https://github.com/torvalds/linux/commit/6c9b40844751ea30c72f7a2f92f4d704bc6b2927))